### PR TITLE
fix: warnings when running bootstrap

### DIFF
--- a/devenv/devenv.mk
+++ b/devenv/devenv.mk
@@ -5,7 +5,7 @@ CONFIG_EMAIL_FILE = $(CONFIG_HOME)/email
 CONFIG_FULLNAME_FILE = $(CONFIG_HOME)/fullname
 CONFIG_HOME = $(HOME)/.config/dalinjun
 
-bootstrap: #info: Bootstrap development environment
+bootstrap:: #info: Bootstrap development environment
 ifeq ($(BOOTSTRAP_INIT_FOUND),1)
 	@make bootstrap.init
 endif


### PR DESCRIPTION
This was caused by the target not being
marked as overrideable.

Signed-off-by: Andreas Metsälä <andreas.metsala@dalinjun.com>
